### PR TITLE
MCMC sampling bug fix for more than 1 jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,119 @@
+*~
+.pypirc
+~*
+tmp*
+tags
+data
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+.vscode
+*.swp
+
+# osx generated files
+.DS_Store
+.DS_Store?
+.Trashes
+ehthumbs.db
+Thumbs.db
+.idea

--- a/lifetime-value/pareto-nbd.ipynb
+++ b/lifetime-value/pareto-nbd.ipynb
@@ -436,7 +436,8 @@
     "    loglikelihood = ParetoNBD(\"loglikelihood\", mu=mu, lambda_=lambda_, observed={'x': x, 't_x': t_x, 'T': T})\n",
     "    \n",
     "    # Sample the model\n",
-    "    trace = pm.sample(n_draws, init=None)"
+    "    njobs = 2\n",
+    "    trace = pm.sample(n_draws, init=None, njobs=njobs)"
    ]
   },
   {

--- a/lifetime-value/pareto-nbd.ipynb
+++ b/lifetime-value/pareto-nbd.ipynb
@@ -838,7 +838,9 @@
   {
    "cell_type": "code",
    "execution_count": 348,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# holdout period is 39 weeks\n",
@@ -1008,7 +1010,48 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.1"
+  },
+  "toc": {
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix for bug that pm.sample actually draws n_draws * njobs samples (instead of n_draws samples), therefore making the dimension of trace depend on number of cores in the computer being run, in case njobs is not specified. This might cause the holdout period predictions for entire customer cohort at section 1.6.3 to throw an error, if the number of jobs was more than 1 while doing pm.sample.