### PR TITLE
Author update Shinzo Abe -> Makoto Abe

### DIFF
--- a/lifetime-value/pareto-nbd.ipynb
+++ b/lifetime-value/pareto-nbd.ipynb
@@ -972,7 +972,7 @@
     "Probabilistic models are popular in the customer lifetime value literature. The following are a list of papers for further reading:\n",
     "\n",
     "* Counting Your Customers The Easy Way, Peter S. Fader and Bruce Hardie, http://brucehardie.com/papers/018/fader_et_al_mksc_05.pdf\n",
-    "* Counting Your Customers One By One, A Hierarchical Bayes Extension to the Pareto/NBD Model, Shinzo Abe, http://pubsonline.informs.org/doi/abs/10.1287/mksc.1090.0502?journalCode=mksc\n",
+    "* Counting Your Customers One By One, A Hierarchical Bayes Extension to the Pareto/NBD Model, Makoto Abe, http://pubsonline.informs.org/doi/abs/10.1287/mksc.1090.0502?journalCode=mksc\n",
     "* Customer Lifetime Value Measurement, Shazad Borle, Siddarth Singh, and Dipak Jain, http://pubsonline.informs.org/doi/abs/10.1287/mnsc.1070.0746?journalCode=mnsc\n",
     "\n",
     "Bayesian Analysis Textbooks\n",


### PR DESCRIPTION
The author for the paper `Counting Your Customers One By One, A Hierarchical Bayes Extension to the Pareto/NBD Model` was incorrectly listed as `Shinzo Abe`, instead of the correct `Makoto Abe`. Please, give credits to the right people.